### PR TITLE
feat: send durable object migrations with `wrangler dev`

### DIFF
--- a/.changeset/popular-badgers-attend.md
+++ b/.changeset/popular-badgers-attend.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: send durable object migrations with `wrangler dev`
+
+This sends up migrations even during `wrangler dev`. This means features like renamed / deleted classes should work as expected even during development.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/736

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -39,6 +39,7 @@ export type DevProps = {
   localProtocol: "https" | "http";
   enableLocalPersistence: boolean;
   bindings: CfWorkerInit["bindings"];
+  migrations: CfWorkerInit["migrations"];
   crons: Config["triggers"]["crons"];
   public: string | undefined;
   assetPaths: AssetPaths | undefined;
@@ -185,6 +186,7 @@ function DevSession(props: DevSessionProps) {
       accountId={props.accountId}
       apiToken={props.apiToken}
       bindings={props.bindings}
+      migrations={props.migrations}
       assetPaths={props.assetPaths}
       public={props.public}
       port={props.port}

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -25,6 +25,7 @@ export function Remote(props: {
   accountId: string | undefined;
   apiToken: string | undefined;
   bindings: CfWorkerInit["bindings"];
+  migrations: CfWorkerInit["migrations"];
   compatibilityDate: string;
   compatibilityFlags: string[] | undefined;
   usageModel: "bundled" | "unbound" | undefined;
@@ -42,6 +43,7 @@ export function Remote(props: {
     accountId: props.accountId,
     apiToken: props.apiToken,
     bindings: props.bindings,
+    migrations: props.migrations,
     assetPaths: props.assetPaths,
     port: props.port,
     compatibilityDate: props.compatibilityDate,
@@ -76,6 +78,7 @@ export function useWorker(props: {
   accountId: string;
   apiToken: string;
   bindings: CfWorkerInit["bindings"];
+  migrations: CfWorkerInit["migrations"];
   assetPaths: AssetPaths | undefined;
   port: number;
   compatibilityDate: string | undefined;
@@ -164,7 +167,7 @@ export function useWorker(props: {
               }),
           },
         },
-        migrations: undefined, // no migrations in dev
+        migrations: props.migrations,
         compatibility_date: compatibilityDate,
         compatibility_flags: compatibilityFlags,
         usage_model: usageModel,
@@ -218,6 +221,7 @@ export function useWorker(props: {
     compatibilityFlags,
     usageModel,
     bindings,
+    props.migrations,
     modules,
     props.env,
     props.legacyEnv,


### PR DESCRIPTION
This sends up migrations even during `wrangler dev`. This means features like renamed / deleted classes should work as expected even during development.

Fixes https://github.com/cloudflare/wrangler2/issues/736

Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/khulnasoft/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
